### PR TITLE
Update lift tests display in review and download reports

### DIFF
--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -2778,6 +2778,14 @@ export default function DownloadReport() {
                               } else {
                                 return `F=${leftAvg.toFixed(2)} E=${rightAvg.toFixed(2)}`;
                               }
+                            } else if (test.testName?.toLowerCase().includes("lift")) {
+                              // Lift tests: show average weight in lbs
+                              const unit = ((test.unitMeasure) || "").toLowerCase();
+                              const baseAvg = leftAvg > 0 ? leftAvg : rightAvg;
+                              const avgLbs = unit === "kg"
+                                ? Math.round(baseAvg * 2.20462 * 10) / 10
+                                : Math.round(baseAvg * 10) / 10;
+                              return `${avgLbs.toFixed(1)} lbs`;
                             } else {
                               // Default format for strength and cardio tests
                               return `L=${leftAvg.toFixed(1)} R=${rightAvg.toFixed(1)}`;

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -2778,13 +2778,18 @@ export default function DownloadReport() {
                               } else {
                                 return `F=${leftAvg.toFixed(2)} E=${rightAvg.toFixed(2)}`;
                               }
-                            } else if (test.testName?.toLowerCase().includes("lift")) {
+                            } else if (
+                              test.testName?.toLowerCase().includes("lift")
+                            ) {
                               // Lift tests: show average weight in lbs
-                              const unit = ((test.unitMeasure) || "").toLowerCase();
+                              const unit = (
+                                test.unitMeasure || ""
+                              ).toLowerCase();
                               const baseAvg = leftAvg > 0 ? leftAvg : rightAvg;
-                              const avgLbs = unit === "kg"
-                                ? Math.round(baseAvg * 2.20462 * 10) / 10
-                                : Math.round(baseAvg * 10) / 10;
+                              const avgLbs =
+                                unit === "kg"
+                                  ? Math.round(baseAvg * 2.20462 * 10) / 10
+                                  : Math.round(baseAvg * 10) / 10;
                               return `${avgLbs.toFixed(1)} lbs`;
                             } else {
                               // Default format for strength and cardio tests
@@ -4250,7 +4255,9 @@ export default function DownloadReport() {
                                             </div>
                                         </div>
 
-                                        ${!isLiftTest ? `
+                                        ${
+                                          !isLiftTest
+                                            ? `
                                         <!-- Right Side Chart -->
                                         <div style="background: #ffffff; border: 2px solid #10b981; border-radius: 8px; padding: 12px; page-break-inside: avoid; flex: 1; min-width: 250px;">
                                             <div style="background: #10b981; color: white; padding: 1px; margin: -12px -12px 12px -12px; font-weight: bold; text-align: center; font-size: 12px;">Right Side</div>
@@ -4359,7 +4366,9 @@ export default function DownloadReport() {
                                                 Avg: ${rightAvg.toFixed(1)} lbs
                                             </div>
                                         </div
-                                        ` : ""}>
+                                        `
+                                            : ""
+                                        }>
                                     </div>
 
                                     <!-- Comparison Summary -->

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -4250,6 +4250,7 @@ export default function DownloadReport() {
                                             </div>
                                         </div>
 
+                                        ${!isLiftTest ? `
                                         <!-- Right Side Chart -->
                                         <div style="background: #ffffff; border: 2px solid #10b981; border-radius: 8px; padding: 12px; page-break-inside: avoid; flex: 1; min-width: 250px;">
                                             <div style="background: #10b981; color: white; padding: 1px; margin: -12px -12px 12px -12px; font-weight: bold; text-align: center; font-size: 12px;">Right Side</div>
@@ -4357,7 +4358,8 @@ export default function DownloadReport() {
                                             <div style="text-align: center; font-size: 10px; color: #10b981; margin-top: 8px; font-weight: bold; background: #d1fae5; padding: 4px; border-radius: 4px;">
                                                 Avg: ${rightAvg.toFixed(1)} lbs
                                             </div>
-                                        </div>
+                                        </div
+                                        ` : ""}>
                                     </div>
 
                                     <!-- Comparison Summary -->

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -5248,7 +5248,7 @@ export default function ReviewReport() {
                                   </div>
 
                                   {/* Graphs Section */}
-                                  {!isCardioTest && (
+                                  {!isCardioTest && !isLiftTest && (
                                     <div>
                                       <h4 className="font-semibold mb-3">
                                         Graph:
@@ -5421,6 +5421,70 @@ export default function ReviewReport() {
                                             {currentDate} 10:20:36 AM
                                           </p>
                                         </div>
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {isLiftTest && (
+                                    <div>
+                                      <h4 className="font-semibold mb-3">Graph:</h4>
+                                      <div className="border border-gray-300 p-2">
+                                        <div className="h-40 bg-white border relative overflow-hidden">
+                                          <div className="flex items-end justify-center h-full p-2 space-x-1">
+                                            {[
+                                              test.leftMeasurements?.trial1,
+                                              test.leftMeasurements?.trial2,
+                                              test.leftMeasurements?.trial3,
+                                              test.leftMeasurements?.trial4,
+                                              test.leftMeasurements?.trial5,
+                                              test.leftMeasurements?.trial6,
+                                            ].map((value, i) => {
+                                              const trialColors = [
+                                                "#3B82F6",
+                                                "#10B981",
+                                                "#F59E0B",
+                                                "#EF4444",
+                                                "#8B5CF6",
+                                                "#06B6D4",
+                                              ];
+                                              const maxVal = Math.max(
+                                                test.leftMeasurements?.trial1 || 0,
+                                                test.leftMeasurements?.trial2 || 0,
+                                                test.leftMeasurements?.trial3 || 0,
+                                                test.leftMeasurements?.trial4 || 0,
+                                                test.leftMeasurements?.trial5 || 0,
+                                                test.leftMeasurements?.trial6 || 0,
+                                                1,
+                                              );
+                                              return (
+                                                <div key={i} className="flex flex-col items-center">
+                                                  <div
+                                                    className="w-4 rounded-t"
+                                                    style={{
+                                                      height: `${Math.max(((value || 0) / maxVal) * 120, 8)}px`,
+                                                      backgroundColor: trialColors[i],
+                                                    }}
+                                                  ></div>
+                                                  <span className="text-xs mt-1">{i + 1}</span>
+                                                </div>
+                                              );
+                                            })}
+                                          </div>
+
+                                          {/* Y-axis labels */}
+                                          <div className="absolute left-0 top-0 h-full flex flex-col justify-between text-xs py-2">
+                                            <span>{leftAvg.toFixed(0)}</span>
+                                            <span>{(leftAvg * 0.75).toFixed(0)}</span>
+                                            <span>{(leftAvg * 0.5).toFixed(0)}</span>
+                                            <span>{(leftAvg * 0.25).toFixed(0)}</span>
+                                            <span>0</span>
+                                          </div>
+                                        </div>
+                                        <p className="text-center text-xs mt-2">
+                                          <strong>Trials</strong>
+                                          <br />
+                                          {currentDate} 10:20:36 AM
+                                        </p>
                                       </div>
                                     </div>
                                   )}

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -2501,6 +2501,15 @@ export default function ReviewReport() {
                                           } else {
                                             return `F=${leftAvg.toFixed(2)} E=${rightAvg.toFixed(2)}`;
                                           }
+                                        } else if (test.testName?.toLowerCase().includes("lift")) {
+                                          // Lift tests: show average weight in lbs
+                                          const unit = ((test.unitMeasure as any) || "").toLowerCase();
+                                          const baseAvg = leftAvg > 0 ? leftAvg : rightAvg;
+                                          const avgLbs =
+                                            unit === "kg"
+                                              ? Math.round(baseAvg * 2.20462 * 10) / 10
+                                              : Math.round(baseAvg * 10) / 10;
+                                          return `${avgLbs.toFixed(1)} lbs`;
                                         } else {
                                           // Default format for strength and cardio tests
                                           return `L=${leftAvg.toFixed(1)} R=${rightAvg.toFixed(1)}`;
@@ -2547,7 +2556,7 @@ export default function ReviewReport() {
                                           ) {
                                             return `≥${jobReq.lightWork} ${jobReq.unit} (Light) / ≥${jobReq.mediumWork} ${jobReq.unit} (Medium)`;
                                           } else if (jobReq.norm) {
-                                            return `≥${jobReq.norm} ${jobReq.unit}`;
+                                            return `��${jobReq.norm} ${jobReq.unit}`;
                                           }
                                         }
 

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -2501,13 +2501,22 @@ export default function ReviewReport() {
                                           } else {
                                             return `F=${leftAvg.toFixed(2)} E=${rightAvg.toFixed(2)}`;
                                           }
-                                        } else if (test.testName?.toLowerCase().includes("lift")) {
+                                        } else if (
+                                          test.testName
+                                            ?.toLowerCase()
+                                            .includes("lift")
+                                        ) {
                                           // Lift tests: show average weight in lbs
-                                          const unit = ((test.unitMeasure as any) || "").toLowerCase();
-                                          const baseAvg = leftAvg > 0 ? leftAvg : rightAvg;
+                                          const unit = (
+                                            (test.unitMeasure as any) || ""
+                                          ).toLowerCase();
+                                          const baseAvg =
+                                            leftAvg > 0 ? leftAvg : rightAvg;
                                           const avgLbs =
                                             unit === "kg"
-                                              ? Math.round(baseAvg * 2.20462 * 10) / 10
+                                              ? Math.round(
+                                                  baseAvg * 2.20462 * 10,
+                                                ) / 10
                                               : Math.round(baseAvg * 10) / 10;
                                           return `${avgLbs.toFixed(1)} lbs`;
                                         } else {
@@ -3660,7 +3669,6 @@ export default function ReviewReport() {
                                     ) : isLiftTest ? (
                                       // Lift Results - Six Trials (single table)
                                       <div>
-
                                         {(() => {
                                           const unit = (
                                             (test.unitMeasure as any) || ""
@@ -5427,7 +5435,9 @@ export default function ReviewReport() {
 
                                   {isLiftTest && (
                                     <div>
-                                      <h4 className="font-semibold mb-3">Graph:</h4>
+                                      <h4 className="font-semibold mb-3">
+                                        Graph:
+                                      </h4>
                                       <div className="border border-gray-300 p-2">
                                         <div className="h-40 bg-white border relative overflow-hidden">
                                           <div className="flex items-end justify-center h-full p-2 space-x-1">
@@ -5448,24 +5458,36 @@ export default function ReviewReport() {
                                                 "#06B6D4",
                                               ];
                                               const maxVal = Math.max(
-                                                test.leftMeasurements?.trial1 || 0,
-                                                test.leftMeasurements?.trial2 || 0,
-                                                test.leftMeasurements?.trial3 || 0,
-                                                test.leftMeasurements?.trial4 || 0,
-                                                test.leftMeasurements?.trial5 || 0,
-                                                test.leftMeasurements?.trial6 || 0,
+                                                test.leftMeasurements?.trial1 ||
+                                                  0,
+                                                test.leftMeasurements?.trial2 ||
+                                                  0,
+                                                test.leftMeasurements?.trial3 ||
+                                                  0,
+                                                test.leftMeasurements?.trial4 ||
+                                                  0,
+                                                test.leftMeasurements?.trial5 ||
+                                                  0,
+                                                test.leftMeasurements?.trial6 ||
+                                                  0,
                                                 1,
                                               );
                                               return (
-                                                <div key={i} className="flex flex-col items-center">
+                                                <div
+                                                  key={i}
+                                                  className="flex flex-col items-center"
+                                                >
                                                   <div
                                                     className="w-4 rounded-t"
                                                     style={{
                                                       height: `${Math.max(((value || 0) / maxVal) * 120, 8)}px`,
-                                                      backgroundColor: trialColors[i],
+                                                      backgroundColor:
+                                                        trialColors[i],
                                                     }}
                                                   ></div>
-                                                  <span className="text-xs mt-1">{i + 1}</span>
+                                                  <span className="text-xs mt-1">
+                                                    {i + 1}
+                                                  </span>
                                                 </div>
                                               );
                                             })}
@@ -5474,9 +5496,15 @@ export default function ReviewReport() {
                                           {/* Y-axis labels */}
                                           <div className="absolute left-0 top-0 h-full flex flex-col justify-between text-xs py-2">
                                             <span>{leftAvg.toFixed(0)}</span>
-                                            <span>{(leftAvg * 0.75).toFixed(0)}</span>
-                                            <span>{(leftAvg * 0.5).toFixed(0)}</span>
-                                            <span>{(leftAvg * 0.25).toFixed(0)}</span>
+                                            <span>
+                                              {(leftAvg * 0.75).toFixed(0)}
+                                            </span>
+                                            <span>
+                                              {(leftAvg * 0.5).toFixed(0)}
+                                            </span>
+                                            <span>
+                                              {(leftAvg * 0.25).toFixed(0)}
+                                            </span>
                                             <span>0</span>
                                           </div>
                                         </div>

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -3651,54 +3651,6 @@ export default function ReviewReport() {
                                     ) : isLiftTest ? (
                                       // Lift Results - Six Trials (single table)
                                       <div>
-                                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-2">
-                                          <div className="text-xs sm:col-span-2">
-                                            <strong>CV%:</strong> {leftCV}%
-                                          </div>
-                                          {(() => {
-                                            const raw = parseFloat(
-                                              (test.valueToBeTestedNumber as any) ||
-                                                "",
-                                            );
-                                            const unit = (
-                                              (test.unitMeasure as any) || ""
-                                            ).toLowerCase();
-                                            let normLbs = 0;
-                                            if (!Number.isNaN(raw) && raw > 0) {
-                                              normLbs =
-                                                unit === "kg"
-                                                  ? Math.round(
-                                                      raw * 2.20462 * 10,
-                                                    ) / 10
-                                                  : unit === "lbs"
-                                                    ? Math.round(raw * 10) / 10
-                                                    : 0;
-                                            }
-                                            return normLbs > 0 ? (
-                                              <div className="text-xs">
-                                                <strong>Norm Weight:</strong>{" "}
-                                                {normLbs} lbs
-                                              </div>
-                                            ) : null;
-                                          })()}
-                                          {(() => {
-                                            const unit = (
-                                              (test.unitMeasure as any) || ""
-                                            ).toLowerCase();
-                                            const avgLbs =
-                                              unit === "kg"
-                                                ? Math.round(
-                                                    leftAvg * 2.20462 * 10,
-                                                  ) / 10
-                                                : Math.round(leftAvg * 10) / 10;
-                                            return (
-                                              <div className="text-xs sm:col-span-2">
-                                                <strong>Avg Weight:</strong>{" "}
-                                                {avgLbs} lbs
-                                              </div>
-                                            );
-                                          })()}
-                                        </div>
 
                                         {(() => {
                                           const unit = (


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR consolidates the lift test display across review and download reports to:
- Remove the separated CV% and average weight section from lift tests in the review report
- Show average weight values in the Test Results and Job Match table for lift tests
- Display only one bar graph for lift tests instead of separate left/right charts
- Ensure consistent formatting between review and download reports

## Code changes

**ReviewReport.tsx:**
- Added lift test detection logic to show average weight in lbs in the Test Results table
- Removed the separate CV% and average weight display section for lift tests
- Added conditional rendering to exclude lift tests from dual-chart display (`!isLiftTest`)
- Implemented single bar graph for lift tests showing all 6 trials with color-coded bars

**DownloadReport.tsx:**
- Added lift test detection and average weight calculation for the Test Results table
- Modified chart rendering to show only single chart for lift tests (excluded right side chart)
- Added unit conversion logic (kg to lbs) for consistent weight display

The changes ensure lift test data is displayed consistently in the main tables while removing redundant sections and providing a single, clear visualization.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 50`

🔗 [Edit in Builder.io](https://builder.io/app/projects/47bac44f857f476b97f66d27a16cd13e/pixel-verse)

👀 [Preview Link](https://47bac44f857f476b97f66d27a16cd13e-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>47bac44f857f476b97f66d27a16cd13e</projectId>-->
<!--<branchName>pixel-verse</branchName>-->