### PR TITLE
Hide incomplete test sections for static lifts

### DIFF
--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -3812,8 +3812,9 @@ export default function DownloadReport() {
               testName.includes("cardio") ||
               testName.includes("cardiovascular");
             const isStaticLift =
-              ((String(test.testId || testName).toLowerCase().includes("static-lift")) ||
-               testName.includes("static"));
+              String(test.testId || testName)
+                .toLowerCase()
+                .includes("static-lift") || testName.includes("static");
 
             // Determine if this test needs a page break
             // Force page breaks for first test, lift tests, range of motion tests, and specific tests
@@ -4405,7 +4406,9 @@ export default function DownloadReport() {
                                 }
 
                                 ${
-                                  !test.demonstrated && !isCardioTest && !isStaticLift
+                                  !test.demonstrated &&
+                                  !isCardioTest &&
+                                  !isStaticLift
                                     ? `
                                     <div style="margin: 8px 0 12px 0;">
                                         <p style="font-size: 11px; font-weight: bold;">Reason For Incomplete Test:</p>

--- a/client/pages/DownloadReport.tsx
+++ b/client/pages/DownloadReport.tsx
@@ -3811,6 +3811,9 @@ export default function DownloadReport() {
               testName.includes("step") ||
               testName.includes("cardio") ||
               testName.includes("cardiovascular");
+            const isStaticLift =
+              ((String(test.testId || testName).toLowerCase().includes("static-lift")) ||
+               testName.includes("static"));
 
             // Determine if this test needs a page break
             // Force page breaks for first test, lift tests, range of motion tests, and specific tests
@@ -4402,7 +4405,7 @@ export default function DownloadReport() {
                                 }
 
                                 ${
-                                  !test.demonstrated && !isCardioTest
+                                  !test.demonstrated && !isCardioTest && !isStaticLift
                                     ? `
                                     <div style="margin: 8px 0 12px 0;">
                                         <p style="font-size: 11px; font-weight: bold;">Reason For Incomplete Test:</p>

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -596,7 +596,7 @@ export default function ReviewReport() {
                   <div className="ml-2 space-y-1">
                     <p>• Activity Overview</p>
                     <p>• Extremity Strength</p>
-                    <p>• Occupational Tasks</p>
+                    <p>�� Occupational Tasks</p>
                     <p>• Range of Motion (Spine)</p>
                   </div>
                   <p className="mt-4">Appendix One: Reference Charts</p>
@@ -2574,7 +2574,7 @@ export default function ReviewReport() {
                                             jobReq.functionalMin &&
                                             jobReq.norm
                                           ) {
-                                            return `≥${jobReq.functionalMin}° (Min) / ≥${jobReq.norm}° (Normal)`;
+                                            return `≥${jobReq.functionalMin}�� (Min) / ≥${jobReq.norm}° (Normal)`;
                                           } else if (jobReq.norm) {
                                             return `≥${jobReq.norm}°`;
                                           }
@@ -3451,6 +3451,9 @@ export default function ReviewReport() {
                         const isLiftTest =
                           testName.includes("lift") ||
                           testName.includes("carry");
+                        const isStaticLift =
+                          (String(test.testId || testName).toLowerCase().includes("static-lift")) ||
+                          testName.includes("static");
                         const isStrengthTest =
                           testName.includes("strength") ||
                           testName.includes("force") ||
@@ -5259,7 +5262,7 @@ export default function ReviewReport() {
                                       </p>
                                     )}
 
-                                    {!test.demonstrated && !isCardioTest && (
+                                    {!test.demonstrated && !isCardioTest && !isStaticLift && (
                                       <div className="mb-4">
                                         <p className="text-sm font-semibold">
                                           Reason For Incomplete Test:

--- a/client/pages/ReviewReport.tsx
+++ b/client/pages/ReviewReport.tsx
@@ -3452,7 +3452,9 @@ export default function ReviewReport() {
                           testName.includes("lift") ||
                           testName.includes("carry");
                         const isStaticLift =
-                          (String(test.testId || testName).toLowerCase().includes("static-lift")) ||
+                          String(test.testId || testName)
+                            .toLowerCase()
+                            .includes("static-lift") ||
                           testName.includes("static");
                         const isStrengthTest =
                           testName.includes("strength") ||
@@ -5262,22 +5264,24 @@ export default function ReviewReport() {
                                       </p>
                                     )}
 
-                                    {!test.demonstrated && !isCardioTest && !isStaticLift && (
-                                      <div className="mb-4">
-                                        <p className="text-sm font-semibold">
-                                          Reason For Incomplete Test:
-                                        </p>
-                                        <p className="text-sm">
-                                          Limited by pain/discomfort
-                                        </p>
-                                        <p className="text-sm font-semibold mt-2">
-                                          Endpoint Condition:
-                                        </p>
-                                        <p className="text-sm">
-                                          Psychophysical
-                                        </p>
-                                      </div>
-                                    )}
+                                    {!test.demonstrated &&
+                                      !isCardioTest &&
+                                      !isStaticLift && (
+                                        <div className="mb-4">
+                                          <p className="text-sm font-semibold">
+                                            Reason For Incomplete Test:
+                                          </p>
+                                          <p className="text-sm">
+                                            Limited by pain/discomfort
+                                          </p>
+                                          <p className="text-sm font-semibold mt-2">
+                                            Endpoint Condition:
+                                          </p>
+                                          <p className="text-sm">
+                                            Psychophysical
+                                          </p>
+                                        </div>
+                                      )}
                                   </div>
 
                                   {/* Graphs Section */}


### PR DESCRIPTION
## Purpose
Remove the "Reason for Incomplete Test" and "Endpoint Condition" sections from static lift tests in both review and download report files, as these sections are not needed for static lift test types.

## Code changes
- Added `isStaticLift` detection logic to identify static lift tests by checking for "static-lift" in test ID or "static" in test name
- Modified conditional rendering in both ReviewReport.tsx and DownloadReport.tsx to exclude incomplete test sections when `!isStaticLift` is true
- Updated the condition from `!test.demonstrated && !isCardioTest` to `!test.demonstrated && !isCardioTest && !isStaticLift` to prevent showing these sections for static lift testsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 52`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a8678e99447e47fd8a10b26a7642d0a9/zen-haven)

👀 [Preview Link](https://a8678e99447e47fd8a10b26a7642d0a9-zen-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a8678e99447e47fd8a10b26a7642d0a9</projectId>-->
<!--<branchName>zen-haven</branchName>-->